### PR TITLE
Created DetectedObjectCache type

### DIFF
--- a/include/cooperative_perception/detected_object.hpp
+++ b/include/cooperative_perception/detected_object.hpp
@@ -22,6 +22,7 @@
 #define COOPERATIVE_PERCEPTION_DETECTED_OBJECT_HPP
 
 #include <variant>
+#include <map>
 #include <boost/container/static_vector.hpp>
 #include <units.h>
 
@@ -74,6 +75,15 @@ inline constexpr auto kMaxDetectedObjects{ 200U };
  * @brief Container for DetectedObject variables
  */
 using DetectedObjectList = boost::container::static_vector<DetectedObjectType, kMaxDetectedObjects>;
+
+/**
+ * @brief A data store that caches the most recent DetectedObjects
+ *
+ *  BSM and SDSM messages report a TemporaryID, which may be assumed to be unique during
+ *  a CDA CP interaction. This TemporaryID will be treated as a unique string that is associated
+ *  with the most recent DetectedObject with that ID.
+ */
+using DetectedObjectCache = std::map<std::string, DetectedObjectType>;
 
 }  // namespace cooperative_perception
 


### PR DESCRIPTION
The DetectedObjectCache is required for Remote Object Tracking's temporal and spatial alignment.

<!-- Thanks for the contribution, this is awesome. -->

# PR Details

This PR provides a DetectedObjectCache type that maps an incoming report's ID to its DetectedObjectType.
This cache would be used by a Remote Object Tracking process to support the alignment of the data between process executions. 

<!--- Describe your changes in detail -->

## Related Issue

#24 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Small enough change that no tests were developed.

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
