### PR TITLE
Clean up scoring implementation

### DIFF
--- a/include/cooperative_perception/scoring.hpp
+++ b/include/cooperative_perception/scoring.hpp
@@ -25,58 +25,52 @@
 #include <map>
 #include <utility>
 #include <type_traits>
+#include <stdexcept>
 
 #include "cooperative_perception/track.hpp"
 #include "cooperative_perception/detected_object.hpp"
-#include "cooperative_perception/ctra_model.hpp"
-#include "cooperative_perception/ctrv_model.hpp"
 
 namespace cooperative_perception
 {
-template <typename DetectedObject, typename Track>
-auto mahalanobis_distance(DetectedObject object, Track track) -> float
-{
-  return mahalanobis_distance(track.state, track.covariance, object.state);
-}
 
-template <typename DetectedObject, typename Track>
-auto euclidean_distance(DetectedObject object, Track track) -> float
-{
-  return euclidean_distance(object.state, track.state);
-}
+constexpr utils::Visitor uuid_visitor{ [](const auto& entity) { return entity.uuid; } };
 
-constexpr utils::Visitor kUuidExtractor{ [](const auto& entity) { return entity.uuid; } };
-constexpr utils::Visitor kEuclideanDistanceGetter{
+constexpr utils::Visitor euclidean_distance_visitor{
   [](const auto& track,
      const auto& object) -> std::enable_if_t<std::is_same_v<decltype(track.state), decltype(object.state)>, float> {
     return euclidean_distance(track.state, object.state);
   },
-  [](const auto& track, const auto& object)
-      -> std::enable_if_t<!std::is_same_v<decltype(track.state), decltype(object.state)>, float> { return -1.0F; },
+  [](const auto& track,
+     const auto& object) -> std::enable_if_t<!std::is_same_v<decltype(track.state), decltype(object.state)>, float> {
+    throw std::invalid_argument("Track and object states are incompatible for calculating distance.");
+  },
 };
-constexpr utils::Visitor kMahalanobisDistanceGetter{
+
+constexpr utils::Visitor mahalanobis_distance_visitor{
   [](const auto& track,
      const auto& object) -> std::enable_if_t<std::is_same_v<decltype(track.state), decltype(object.state)>, float> {
     return mahalanobis_distance(track.state, track.covariance, object.state);
   },
-  [](const auto& track, const auto& object)
-      -> std::enable_if_t<!std::is_same_v<decltype(track.state), decltype(object.state)>, float> { return -1.0F; },
+  [](const auto& track,
+     const auto& object) -> std::enable_if_t<!std::is_same_v<decltype(track.state), decltype(object.state)>, float> {
+    throw std::invalid_argument("Track and object states are incompatible for calculating distance.");
+  },
 };
 
 template <typename DistanceVisitor>
 auto score_tracks_and_objects(const std::vector<TrackType>& tracks, const std::vector<DetectedObjectType>& objects,
-                              const DistanceVisitor& distance_metric)
+                              const DistanceVisitor& distance_visitor)
 {
   std::map<std::pair<std::string, std::string>, float> scores;
 
   for (const auto& track : tracks)
   {
-    const auto track_uuid = std::visit(kUuidExtractor, track);
+    const auto track_uuid = std::visit(uuid_visitor, track);
 
     for (const auto& object : objects)
     {
-      const auto object_uuid = std::visit(kUuidExtractor, object);
-      scores[std::pair{ track_uuid, object_uuid }] = std::visit(distance_metric, track, object);
+      const auto object_uuid = std::visit(uuid_visitor, object);
+      scores[std::pair{ track_uuid, object_uuid }] = std::visit(distance_visitor, track, object);
     }
   }
 

--- a/test/test_scoring.cpp
+++ b/test/test_scoring.cpp
@@ -38,7 +38,7 @@ TEST(TestScoring, CtrvEuclideanDistance)
 
   const auto track = TestTrack{ .state{ cp::CtrvState{ 6_m, 7_m, 8_mps, cp::Angle(3_rad), 10_rad_per_s } } };
 
-  const auto euclidean_dist = cp::euclidean_distance(object, track);
+  const auto euclidean_dist = cp::euclidean_distance(object.state, track.state);
   EXPECT_FLOAT_EQ(euclidean_dist, 7.0710678118654755F);
 }
 
@@ -59,7 +59,7 @@ TEST(TestScoring, CtrvMahalanobisDistance)
                                                        { -0.0022, 0.0071, 0.0007, 0.0098, 0.0100 },
                                                        { -0.0020, 0.0060, 0.0008, 0.0100, 0.0123 } } } };
 
-  const auto mahalanobis_dist = cp::mahalanobis_distance(object, track);
+  const auto mahalanobis_dist = cp::mahalanobis_distance(track.state, track.covariance, object.state);
   EXPECT_FLOAT_EQ(mahalanobis_dist, 74.37377728947332F);
 }
 
@@ -75,7 +75,7 @@ TEST(TestScoring, CtraEuclideanDistance)
     units::time::second_t{ 0 }, cp::CtraState{ 6_m, 7_m, 8_mps, cp::Angle(3_rad), 10_rad_per_s, 12_mps_sq }
   };
 
-  const auto euclidean_dist = cp::euclidean_distance(object, track);
+  const auto euclidean_dist = cp::euclidean_distance(object.state, track.state);
   EXPECT_FLOAT_EQ(euclidean_dist, 7.0710678118654755);
 }
 
@@ -98,7 +98,7 @@ TEST(TestScoring, CtraMahalanobisDistance)
                                     { 0.5, 0.123, -0.34, 0.009, 0.0021, -0.8701 },
                                 } } };
 
-  const auto mahalanobis_dist = cp::mahalanobis_distance(object, track);
+  const auto mahalanobis_dist = cp::mahalanobis_distance(track.state, track.covariance, object.state);
   EXPECT_FLOAT_EQ(mahalanobis_dist, 122.3575692494651);
 }
 
@@ -123,7 +123,7 @@ TEST(TestScoring, TrackToObjectScoringEuclidean)
                 .uuid{ "test_object2" } }
   };
 
-  const auto scores = cp::score_tracks_and_objects(tracks, objects, cp::kEuclideanDistanceGetter);
+  const auto scores = cp::score_tracks_and_objects(tracks, objects, cp::euclidean_distance_visitor);
 
   const std::map<std::pair<std::string, std::string>, float> expected_scores{
     { std::pair{ "test_track1", "test_object1" }, 7.0710678 },
@@ -177,7 +177,7 @@ TEST(TestScoring, TrackToObjectScoringMahalanobis)
                 .uuid{ "test_object2" } }
   };
 
-  const auto scores = cp::score_tracks_and_objects(tracks, objects, cp::kMahalanobisDistanceGetter);
+  const auto scores = cp::score_tracks_and_objects(tracks, objects, cp::mahalanobis_distance_visitor);
 
   const std::map<std::pair<std::string, std::string>, float> expected_scores{
     { std::pair{ "test_track1", "test_object1" }, 122.35757 },

--- a/test/test_scoring.cpp
+++ b/test/test_scoring.cpp
@@ -113,30 +113,43 @@ TEST(TestScoring, TrackToObjectScoringEuclidean)
     TestTrack{ .state{ cp::CtraState{ 6_m, 7_m, 8_mps, cp::Angle(3_rad), 10_rad_per_s, 12_mps_sq } },
                .uuid{ "test_track1" } },
     TestTrack{ .state{ cp::CtraState{ 8_m, 2_m, 3_mps, cp::Angle(1_rad), 12_rad_per_s, 11_mps_sq } },
-               .uuid{ "test_track2" } }
+               .uuid{ "test_track2" } },
+    cp::Track<cp::CtrvState, cp::CtrvStateCovariance>{ .state{ 1_m, 1_m, 1_mps, cp::Angle(1_rad), 1_rad_per_s },
+                                                       .uuid{ "test_track3" } }
   };
 
   const std::vector<cp::DetectedObjectType> objects{
     TestObject{ .state{ cp::CtraState{ 1_m, 2_m, 3_mps, cp::Angle(3_rad), 5_rad_per_s, 6_mps_sq } },
                 .uuid{ "test_object1" } },
     TestObject{ .state{ cp::CtraState{ 2_m, 3_m, 6_mps, cp::Angle(2_rad), 20_rad_per_s, 9_mps_sq } },
-                .uuid{ "test_object2" } }
+                .uuid{ "test_object2" } },
+    cp::DetectedObject<cp::CtrvState, cp::CtrvStateCovariance>{
+        .state{ 1_m, 1_m, 1_mps, cp::Angle(1_rad), 1_rad_per_s }, .uuid{ "test_object3" } }
   };
 
   const auto scores = cp::score_tracks_and_objects(tracks, objects, cp::euclidean_distance_visitor);
 
-  const std::map<std::pair<std::string, std::string>, float> expected_scores{
+  const std::map<std::pair<std::string, std::string>, std::optional<float>> expected_scores{
     { std::pair{ "test_track1", "test_object1" }, 7.0710678 },
     { std::pair{ "test_track1", "test_object2" }, 5.7445626 },
+    { std::pair{ "test_track1", "test_object3" }, std::nullopt },
     { std::pair{ "test_track2", "test_object1" }, 7.2801099 },
     { std::pair{ "test_track2", "test_object2" }, 6.1644139 },
+    { std::pair{ "test_track2", "test_object3" }, std::nullopt },
+    { std::pair{ "test_track3", "test_object1" }, std::nullopt },
+    { std::pair{ "test_track3", "test_object2" }, std::nullopt },
+    { std::pair{ "test_track3", "test_object3" }, 0.0 },
   };
 
   EXPECT_EQ(std::size(scores), std::size(expected_scores));
 
   for (const auto& [key, value] : scores)
   {
-    EXPECT_FLOAT_EQ(expected_scores.at(key), value);
+    ASSERT_EQ(expected_scores.at(key).has_value(), value.has_value());
+    if (expected_scores.at(key).has_value())
+    {
+      EXPECT_FLOAT_EQ(expected_scores.at(key).value(), value.value());
+    }
   }
 }
 
@@ -167,29 +180,48 @@ TEST(TestScoring, TrackToObjectScoringMahalanobis)
                    { -0.0020, 0.0060, 0.0008, 0.0100, 0.0123, 0.0021 },
                    { 0.5, 0.123, -0.34, 0.009, 0.0021, -0.8701 },
                } },
-               .uuid{ "test_track2" } }
+               .uuid{ "test_track2" } },
+    cp::Track<cp::CtrvState, cp::CtrvStateCovariance>{
+        .state{ 1_m, 1_m, 1_mps, cp::Angle(1_rad), 1_rad_per_s },
+        .covariance{ cp::CtrvStateCovariance{ { 0.0043, -0.0013, 0.0030, -0.0022, -0.0020 },
+                                              { -0.0013, 0.0077, 0.0011, 0.0071, 0.0060 },
+                                              { 0.0030, 0.0011, 0.0054, 0.0007, 0.0008 },
+                                              { -0.0022, 0.0071, 0.0007, 0.0098, 0.0100 },
+                                              { -0.0020, 0.0060, 0.0008, 0.0100, 0.0123 } } },
+        .uuid{ "test_track3" } }
   };
 
   const std::vector<cp::DetectedObjectType> objects{
     TestObject{ .state{ cp::CtraState{ 1_m, 2_m, 3_mps, cp::Angle(3_rad), 5_rad_per_s, 6_mps_sq } },
                 .uuid{ "test_object1" } },
     TestObject{ .state{ cp::CtraState{ 2_m, 3_m, 6_mps, cp::Angle(2_rad), 20_rad_per_s, 9_mps_sq } },
-                .uuid{ "test_object2" } }
+                .uuid{ "test_object2" } },
+    cp::DetectedObject<cp::CtrvState, cp::CtrvStateCovariance>{
+        .state{ 1_m, 1_m, 1_mps, cp::Angle(1_rad), 1_rad_per_s }, .uuid{ "test_object3" } }
   };
 
   const auto scores = cp::score_tracks_and_objects(tracks, objects, cp::mahalanobis_distance_visitor);
 
-  const std::map<std::pair<std::string, std::string>, float> expected_scores{
+  const std::map<std::pair<std::string, std::string>, std::optional<float>> expected_scores{
     { std::pair{ "test_track1", "test_object1" }, 122.35757 },
     { std::pair{ "test_track1", "test_object2" }, 90.688416 },
+    { std::pair{ "test_track1", "test_object3" }, std::nullopt },
     { std::pair{ "test_track2", "test_object1" }, 109.70312 },
     { std::pair{ "test_track2", "test_object2" }, 95.243896 },
+    { std::pair{ "test_track2", "test_object3" }, std::nullopt },
+    { std::pair{ "test_track3", "test_object1" }, std::nullopt },
+    { std::pair{ "test_track3", "test_object2" }, std::nullopt },
+    { std::pair{ "test_track3", "test_object3" }, 0.0 },
   };
 
   EXPECT_EQ(std::size(scores), std::size(expected_scores));
 
   for (const auto& [key, value] : scores)
   {
-    EXPECT_FLOAT_EQ(expected_scores.at(key), value);
+    ASSERT_EQ(expected_scores.at(key).has_value(), value.has_value());
+    if (expected_scores.at(key).has_value())
+    {
+      EXPECT_FLOAT_EQ(expected_scores.at(key).value(), value.value());
+    }
   }
 }


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR cleans up the scoring implementation. It removes some unused functions and unifies the visitor names used in the scoring process.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

Closes #32 

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Removing bloat and maintaining consistent naming is a good code hygiene practice. 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

All existing unit tests passed.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
