### PR TITLE
Add gating functionality

### DIFF
--- a/include/cooperative_perception/gating.hpp
+++ b/include/cooperative_perception/gating.hpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 Leidos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ */
+
+#ifndef COOPERATIVE_PERCEPTION_GATING_HPP
+#define COOPERATIVE_PERCEPTION_GATING_HPP
+
+#include <vector>
+
+#include "cooperative_perception/scoring.hpp"
+
+namespace cooperative_perception
+{
+
+template <typename UnaryPredicate>
+auto pruneTrackAndDetectionScoresIf(ScoreMap& scores, UnaryPredicate should_prune) -> void
+{
+  std::vector<std::pair<std::string, std::string>> keys_to_prune;
+
+  for (const auto& [key, score] : scores)
+  {
+    if (should_prune(score))
+    {
+      keys_to_prune.emplace_back(key);
+    }
+  }
+
+  for (const auto& key : keys_to_prune)
+  {
+    scores.erase(key);
+  }
+}
+
+}  // namespace cooperative_perception
+
+#endif  // COOPERATIVE_PERCEPTION_GATING_HPP

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(test_cooperative_perceptionExecutable
   test_unscented_transform.cpp
   test_host_object_alignment.cpp
   test_scoring.cpp
+  test_gating.cpp
 )
 
 target_link_libraries(test_cooperative_perceptionExecutable

--- a/test/test_gating.cpp
+++ b/test/test_gating.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023 Leidos
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/*
+ * Developed by the Human and Vehicle Ensembles (HIVE) Lab at Virginia Commonwealth University (VCU)
+ */
+
+#include <cooperative_perception/scoring.hpp>
+#include <cooperative_perception/gating.hpp>
+
+#include <gtest/gtest.h>
+
+namespace cp = cooperative_perception;
+
+TEST(TestGating, TestPruning)
+{
+  cp::ScoreMap scores{ { { "track1", "detection1" }, 10.0 },
+                       { { "track2", "detection2" }, 20.0 },
+                       { { "track3", "detection3" }, 30.0 } };
+
+  const cp::ScoreMap expected_pruned_scores{ { { "track1", "detection1" }, 10.0 },
+                                             { { "track2", "detection2" }, 20.0 } };
+
+  cp::pruneTrackAndDetectionScoresIf(scores, [](const auto& score) { return score > 25.0; });
+
+  EXPECT_EQ(std::size(scores), std::size(expected_pruned_scores));
+
+  for (const auto& [pair, score] : scores)
+  {
+    EXPECT_FLOAT_EQ(expected_pruned_scores.at(pair), score);
+  }
+}


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR adds a function to prune track-to-detection scores. Gating functionality allows us to prune track-to-detection scores that are highly unlikely. This saves some computation during the association stage.

## Related GitHub Issue

<!--- This project only accepts pull requests related to open GitHub issues or Jira Keys -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please DO NOT name partially fixed issues, instead open an issue specific to this fix -->
<!--- Please link to the issue here: -->

Closes usdot-fhwa-stol/cooperative-perception-core#38
Depends on usdot-fhwa-stol/cooperative-perception-core#37

## Related Jira Key

<!-- e.g. CAR-123 -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

See description

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the [**CONTRIBUTING**](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md) document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
